### PR TITLE
Delete Backup History config flag.

### DIFF
--- a/lib/dbt/drivers/dialect/sql_server.rb
+++ b/lib/dbt/drivers/dialect/sql_server.rb
@@ -184,7 +184,7 @@ ORDER BY t.Ordinal, t.Name
 
       def drop(database, configuration)
         execute('SET DEADLOCK_PRIORITY HIGH')
-        execute("EXEC msdb.dbo.sp_delete_database_backuphistory @database_name = N'#{configuration.catalog_name}'") unless configuration.delete_backup_history?
+        execute("EXEC msdb.dbo.sp_delete_database_backuphistory @database_name = N'#{configuration.catalog_name}'") if configuration.delete_backup_history?
         if configuration.force_drop?
           execute(<<SQL)
   IF EXISTS

--- a/lib/dbt/drivers/dialect/sql_server.rb
+++ b/lib/dbt/drivers/dialect/sql_server.rb
@@ -51,6 +51,12 @@ class Dbt
       !!@force_drop
     end
 
+    attr_writer :delete_backup_history
+
+    def delete_backup_history?
+      @delete_backup_history.nil? ? true : @delete_backup_history
+    end
+
     attr_writer :reindex_on_import
 
     def reindex_on_import?
@@ -178,7 +184,7 @@ ORDER BY t.Ordinal, t.Name
 
       def drop(database, configuration)
         execute('SET DEADLOCK_PRIORITY HIGH')
-        execute("EXEC msdb.dbo.sp_delete_database_backuphistory @database_name = N'#{configuration.catalog_name}'")
+        execute("EXEC msdb.dbo.sp_delete_database_backuphistory @database_name = N'#{configuration.catalog_name}'") unless configuration.delete_backup_history?
         if configuration.force_drop?
           execute(<<SQL)
   IF EXISTS

--- a/test/test_db_config.rb
+++ b/test/test_db_config.rb
@@ -55,6 +55,7 @@ class TestDbConfig < Dbt::TestCase
     shrink_on_import = true
     reindex_on_import = true
     force_drop = true
+    delete_backup_history = true
 
     config = new_base_config.merge(
       :instance => instance,
@@ -66,7 +67,8 @@ class TestDbConfig < Dbt::TestCase
       :instance_registry_key => instance_registry_key,
       :shrink_on_import => shrink_on_import,
       :reindex_on_import => reindex_on_import,
-      :force_drop => force_drop
+      :force_drop => force_drop,
+      :delete_backup_history => delete_backup_history
     ).merge(options)
     config = config_class.new('sqlserver_test',config)
     assert_base_config(config, 1433)
@@ -82,11 +84,16 @@ class TestDbConfig < Dbt::TestCase
     assert_equal config.shrink_on_import?, shrink_on_import
     assert_equal config.reindex_on_import?, reindex_on_import
     assert_equal config.force_drop?, force_drop
+    assert_equal config.delete_backup_history?, delete_backup_history
 
     assert_equal config.control_catalog_name, 'msdb'
 
     config.force_drop = nil
     assert_equal config.force_drop?, false
+
+    config.delete_backup_history = nil
+    assert_equal config.delete_backup_history?, true
+
     config
   end
 


### PR DESCRIPTION
Added a "delete_backup_history" config parameter so we can disable the deletion of backup history for AWS SQL servers.