### PR TITLE
Revert change to initialisation of Sequences

### DIFF
--- a/lib/dbt/runtime.rb
+++ b/lib/dbt/runtime.rb
@@ -710,7 +710,7 @@ TXT
 
     def generate_standard_sequence_import_sql(sequence_name)
       sql = "DECLARE @Next VARCHAR(50);\n"
-      sql += "SELECT @Next = CAST(current_value AS BIGINT) + 1 FROM [@@TARGET@@].sys.sequences WHERE object_id = OBJECT_ID('[@@TARGET@@].#{sequence_name}');\n"
+      sql += "SELECT @Next = CAST(current_value AS BIGINT) + 1 FROM [@@SOURCE@@].sys.sequences WHERE object_id = OBJECT_ID('[@@SOURCE@@].#{sequence_name}');\n"
       sql += "SET @Next = COALESCE(@Next,'1');"
       sql += "EXEC('USE [@@TARGET@@]; ALTER SEQUENCE #{sequence_name} RESTART WITH ' + @Next );"
       sql

--- a/test/test_runtime_basic.rb
+++ b/test/test_runtime_basic.rb
@@ -1251,7 +1251,7 @@ class TestRuntimeBasic < Dbt::TestCase
 
   def expect_default_sequence(mock, module_name, sequence_name)
     import_banner(module_name, sequence_name, 'D')
-    mock.expects(:execute).with("DECLARE @Next VARCHAR(50);\nSELECT @Next = CAST(current_value AS BIGINT) + 1 FROM [DBT_TEST].sys.sequences WHERE object_id = OBJECT_ID('[DBT_TEST].[#{module_name}].[#{sequence_name}]');\nSET @Next = COALESCE(@Next,'1');EXEC('USE [DBT_TEST]; ALTER SEQUENCE [#{module_name}].[#{sequence_name}] RESTART WITH ' + @Next );", true).in_sequence(@s)
+    mock.expects(:execute).with("DECLARE @Next VARCHAR(50);\nSELECT @Next = CAST(current_value AS BIGINT) + 1 FROM [IMPORT_DB].sys.sequences WHERE object_id = OBJECT_ID('[IMPORT_DB].[#{module_name}].[#{sequence_name}]');\nSET @Next = COALESCE(@Next,'1');EXEC('USE [DBT_TEST]; ALTER SEQUENCE [#{module_name}].[#{sequence_name}] RESTART WITH ' + @Next );", true).in_sequence(@s)
   end
 
   def import_banner(module_name, sequence_name, import_type = 'D')


### PR DESCRIPTION
In a standard import of a table with a sequence it should use the source sequence seed.
Using the target sequence seed is the same as just leaving the target sequence starting at "1", because it's never been used.